### PR TITLE
Use new multi-select separator when loading filters from cookie.

### DIFF
--- a/listable/static/listable/js/listable.js
+++ b/listable/static/listable/js/listable.js
@@ -59,7 +59,7 @@ function listable(moment) {
                 searcher = searcher.replace('^(', '').replace(')$', '');
                 if (searcher != '.*') {
                     var c = parseInt(i) + 1;
-                    var searchers = searcher.split('|');
+                    var searchers = searcher.split('`|`');
                     var select = $("thead > tr > th:nth-child(" + c + ") select");
                     for (var j in searchers) {
                         var option = $(select).children("option[value='" + searchers[j] + "']");


### PR DESCRIPTION
When filters are restored from the cookie, the separator used is the old style separator (`|`, pre v0.8.1) instead of the new style separator (`` `|` ``).