### PR TITLE
Use the paginator's cached `count` instead of doing another count query.

### DIFF
--- a/listable/views.py
+++ b/listable/views.py
@@ -205,10 +205,15 @@ class BaseListableView(ListView):
         except (TypeError, ValueError):
             secho = None
 
+        if "paginator" in context and context["paginator"] is not None:
+            object_count = context["paginator"].count
+        else:
+            object_count = self.object_list.count()
+
         context = {
             "aaData": self.get_rows(object_list),
             "iTotalRecords": self.get_queryset().count(),
-            "iTotalDisplayRecords": self.object_list.count(),
+            "iTotalDisplayRecords": object_count,
             "sEcho": secho,
         }
 


### PR DESCRIPTION
We can save on a `count` query by using the count on the Paginator: https://github.com/django/django/blob/52116774549e27ac5d1ba9423e2fe61c5503a4a4/django/core/paginator.py#L91