### PR TITLE
Cache unfiltered count and add static_live_filters support

### DIFF
--- a/listable-demo/staff/urls.py
+++ b/listable-demo/staff/urls.py
@@ -8,4 +8,9 @@ urlpatterns = [
         views.StaffListLiveFilters.as_view(),
         name="staff-list-live-filters",
     ),
+    path(
+        'staff-list-static-live-filters/',
+        views.StaffListStaticLiveFilters.as_view(),
+        name="staff-list-static-live-filters",
+    ),
 ]

--- a/listable-demo/staff/views.py
+++ b/listable-demo/staff/views.py
@@ -90,3 +90,9 @@ class StaffList(BaseListableView):
 class StaffListLiveFilters(StaffList):
     live_filters = True
     template_name = "staff/staff_list_live_filters.html"
+
+
+class StaffListStaticLiveFilters(StaffListLiveFilters):
+    static_live_filters = {
+        "is_manager": ["True", "False"],
+    }

--- a/listable/views.py
+++ b/listable/views.py
@@ -90,6 +90,13 @@ class BaseListableView(ListView):
     # Live filtering is disabled by default.
     live_filters = False
 
+    # Dictionary mapping field names to lists of static filter values. When a
+    # field is listed here, the corresponding SELECT DISTINCT query in
+    # get_live_filters is skipped and the static values are returned instead.
+    # Useful for fields with a small, known set of values (e.g. booleans).
+    # Example: static_live_filters = {"is_active": ["True", "False"]}
+    static_live_filters = {}
+
     headers = {}
 
     multi_separator = ', '
@@ -247,7 +254,7 @@ class BaseListableView(ListView):
 
         context = {
             "aaData": self.get_rows(object_list),
-            "iTotalRecords": self.get_queryset().count(),
+            "iTotalRecords": getattr(self, '_unfiltered_count', None) or self.get_queryset().count(),
             "iTotalDisplayRecords": object_count,
             "sEcho": secho,
         }
@@ -261,6 +268,11 @@ class BaseListableView(ListView):
         live_filters = []
 
         for field in self.get_fields(request=self.request):
+
+            if field in self.static_live_filters:
+                live_filters.append(self.static_live_filters[field])
+                continue
+
             filter_allowed = self.search_fields.get(field, True)
             widget_type = self.widgets.get(field, TEXT)
 
@@ -358,6 +370,8 @@ class BaseListableView(ListView):
 
         This method is awful :(
         """
+
+        self._unfiltered_count = qs.order_by().count()
 
         cur_tz = timezone.get_current_timezone()
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -305,3 +305,106 @@ class TestViews(TestCase):
         payload_names = [x[1] for x in data]
 
         self.assertListEqual(names, payload_names)
+
+    def test_cached_unfiltered_count(self):
+        """iTotalRecords should use _unfiltered_count cached in filter_queryset
+        rather than calling get_queryset().count() again."""
+
+        client = Client()
+        total = Staff.objects.count()
+
+        # Unfiltered request
+        response = client.get(
+            reverse("staff-list") + "?sEcho=1&iColumns=8&sColumns="
+            "&iDisplayStart=0&iDisplayLength=10",
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+        )
+        payload = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(payload['iTotalRecords'], total)
+
+        # Filtered request — iTotalRecords should still equal the full count
+        url = (
+            reverse("staff-list") +
+            "?sEcho=2&iColumns=8&sColumns="
+            "&iDisplayStart=0&iDisplayLength=10"
+            "&mDataProp_0=0&mDataProp_1=1&mDataProp_2=2&mDataProp_3=3"
+            "&mDataProp_4=4&mDataProp_5=5&mDataProp_6=6&mDataProp_7=7"
+            "&sSearch=&bRegex=false"
+            "&sSearch_0=&bRegex_0=false&bSearchable_0=true"
+            "&sSearch_1=&bRegex_1=false&bSearchable_1=true"
+            "&sSearch_2=inactive&bRegex_2=false&bSearchable_2=true"
+            "&sSearch_3=&bRegex_3=false&bSearchable_3=true"
+            "&sSearch_4=&bRegex_4=false&bSearchable_4=true"
+            "&sSearch_5=&bRegex_5=false&bSearchable_5=true"
+            "&sSearch_6=&bRegex_6=false&bSearchable_6=true"
+            "&sSearch_7=&bRegex_7=false&bSearchable_7=true"
+            "&iSortingCols=0"
+            "&bSortable_0=true&bSortable_1=true&bSortable_2=true"
+            "&bSortable_3=true&bSortable_4=true&bSortable_5=true"
+            "&bSortable_6=true&bSortable_7=true"
+            "&sRangeSeparator=~&_=1414439607637"
+        )
+        response = client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        payload = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(payload['iTotalRecords'], total)
+        inactive_count = Staff.objects.filter(active=INACTIVE).count()
+        self.assertEqual(payload['iTotalDisplayRecords'], inactive_count)
+
+    def test_static_live_filters(self):
+        """Fields listed in static_live_filters should return the declared
+        values instead of running a SELECT DISTINCT query."""
+
+        client = Client()
+        response = client.get(
+            reverse("staff-list-static-live-filters"),
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+        )
+        payload = json.loads(response.content.decode('utf-8'))
+
+        # is_manager is at field index 8 and has static_live_filters declared
+        self.assertEqual(payload['liveFilters'][8], ["True", "False"])
+
+        # Dynamic live filters should still work for other columns
+        self.assertCountEqual(
+            payload['liveFilters'][9],
+            set(escape(s) for s in Staff.objects.values_list('contract_type__name', flat=True)),
+        )
+
+    def test_static_live_filters_unaffected_by_filtering(self):
+        """Static live filter values should remain constant even when other
+        columns are filtered, since they are not derived from the queryset."""
+
+        client = Client()
+        # Filter on active=inactive (column 2)
+        url = (
+            reverse("staff-list-static-live-filters") +
+            "?sEcho=1&iColumns=8&sColumns="
+            "&iDisplayStart=0&iDisplayLength=10"
+            "&mDataProp_0=0&mDataProp_1=1&mDataProp_2=2&mDataProp_3=3"
+            "&mDataProp_4=4&mDataProp_5=5&mDataProp_6=6&mDataProp_7=7"
+            "&sSearch=&bRegex=false"
+            "&sSearch_0=&bRegex_0=false&bSearchable_0=true"
+            "&sSearch_1=&bRegex_1=false&bSearchable_1=true"
+            "&sSearch_2=inactive&bRegex_2=false&bSearchable_2=true"
+            "&sSearch_3=&bRegex_3=false&bSearchable_3=true"
+            "&sSearch_4=&bRegex_4=false&bSearchable_4=true"
+            "&sSearch_5=&bRegex_5=false&bSearchable_5=true"
+            "&sSearch_6=&bRegex_6=false&bSearchable_6=true"
+            "&sSearch_7=&bRegex_7=false&bSearchable_7=true"
+            "&iSortingCols=0"
+            "&bSortable_0=true&bSortable_1=true&bSortable_2=true"
+            "&bSortable_3=true&bSortable_4=true&bSortable_5=true"
+            "&bSortable_6=true&bSortable_7=true"
+            "&sRangeSeparator=~&_=1414439607637"
+        )
+        response = client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        payload = json.loads(response.content.decode('utf-8'))
+
+        # Static values stay the same regardless of active filter
+        self.assertEqual(payload['liveFilters'][8], ["True", "False"])
+
+        # Dynamic filters should reflect the filtered queryset
+        self.assertCountEqual(
+            payload['liveFilters'][9],
+            set(Staff.objects.filter(active=INACTIVE).values_list('contract_type__name', flat=True)),
+        )


### PR DESCRIPTION
get_table_context_data previously called self.get_queryset().count() on every AJAX call request for iTotalRecords. Now, it caches the count at the start of filter_queryset and reuses it.

get_live_filters runs a SELECT DISTINCT query for every relevant column. Updated to allow subclasses to be able to declare static_live_filters for cases where we have a known set of values (such as booleans). This will allow it to skip the DISTINCT query for those fields.